### PR TITLE
build: portable $ORIGIN rpaths + unversioned SONAMEs (drop patchelf need)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,14 @@ add_library(fstats SHARED
     ${MT_SOURCES}
 )
 
+# Resolve the sibling dependency libraries (ferror/linalg/collections) from this
+# library's own directory via an $ORIGIN runpath, so the shipped libfstats.so
+# loads from the repo root on any machine without a post-build patchelf step.
 set_target_properties(fstats PROPERTIES
     OUTPUT_NAME fstats
     POSITION_INDEPENDENT_CODE TRUE
+    INSTALL_RPATH "$ORIGIN"
+    BUILD_WITH_INSTALL_RPATH TRUE
     LIBRARY_OUTPUT_DIRECTORY ${MT_DIR}
     RUNTIME_OUTPUT_DIRECTORY ${MT_DIR}
 )

--- a/dependencies/collections/CMakeLists.txt
+++ b/dependencies/collections/CMakeLists.txt
@@ -9,9 +9,14 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(collections)
 
+# Keep the default unversioned SONAME (libcollections.so) so consumers record a
+# relative DT_NEEDED, and resolve siblings (libferror.so) from the library's own
+# directory via an $ORIGIN runpath. Both let the shipped .so load from the repo
+# root on any machine without a post-build patchelf step.
 set_target_properties(collections PROPERTIES
     OUTPUT_NAME "collections"
-    NO_SONAME ON
+    INSTALL_RPATH "$ORIGIN"
+    BUILD_WITH_INSTALL_RPATH TRUE
     LIBRARY_OUTPUT_DIRECTORY ${MT_DIR}
     RUNTIME_OUTPUT_DIRECTORY ${MT_DIR}
 )

--- a/dependencies/ferror/CMakeLists.txt
+++ b/dependencies/ferror/CMakeLists.txt
@@ -9,9 +9,14 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(ferror)
 
+# Keep the default unversioned SONAME (libferror.so) so consumers record a
+# relative DT_NEEDED, and resolve siblings from the library's own directory via
+# an $ORIGIN runpath. Both let the shipped .so load from the repo root on any
+# machine without a post-build patchelf step.
 set_target_properties(ferror PROPERTIES
     OUTPUT_NAME "ferror"
-    NO_SONAME ON
+    INSTALL_RPATH "$ORIGIN"
+    BUILD_WITH_INSTALL_RPATH TRUE
     LIBRARY_OUTPUT_DIRECTORY ${MT_DIR}
     RUNTIME_OUTPUT_DIRECTORY ${MT_DIR}
 )

--- a/dependencies/linalg/CMakeLists.txt
+++ b/dependencies/linalg/CMakeLists.txt
@@ -9,9 +9,14 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(linalg)
 
+# Keep the default unversioned SONAME (liblinalg.so) so consumers record a
+# relative DT_NEEDED, and resolve siblings (libferror.so) from the library's own
+# directory via an $ORIGIN runpath. Both let the shipped .so load from the repo
+# root on any machine without a post-build patchelf step.
 set_target_properties(linalg PROPERTIES
     OUTPUT_NAME "linalg"
-    NO_SONAME ON
+    INSTALL_RPATH "$ORIGIN"
+    BUILD_WITH_INSTALL_RPATH TRUE
     LIBRARY_OUTPUT_DIRECTORY ${MT_DIR}
     RUNTIME_OUTPUT_DIRECTORY ${MT_DIR}
 )


### PR DESCRIPTION
## Problem

These shared libraries are emitted to the consuming app's directory (`MT_DIR`) and loaded from there. Two settings made the result non-portable:

1. Each dependency (`ferror`/`linalg`/`collections`) was built with **`NO_SONAME ON`**. With no soname to record, a consumer (e.g. `libfstats.so`) recorded the dependency's **absolute build path** as its `DT_NEEDED` (`/abs/path/liblinalg.so`).
2. No target set a runpath, so CMake baked the **absolute build directory** in as `RUNPATH`.

The libraries then only loaded from the exact machine path they were built on, forcing the consumer to rewrite the rpaths post-build (e.g. a `patchelf` step in CI).

## Fix

- **Drop `NO_SONAME ON`** on the three deps → each keeps its default unversioned soname (`libX.so`), so consumers record a **relative** `DT_NEEDED`.
- **`INSTALL_RPATH "$ORIGIN"` + `BUILD_WITH_INSTALL_RPATH TRUE`** on every target (`fstats` + 3 deps) → siblings resolve from the library's **own directory** regardless of where the tree lives.

## Verification (Linux, Release)

After a clean rebuild, every shipped `.so` has a bare `SONAME`, relative `DT_NEEDED`, `RUNPATH = $ORIGIN`, and no absolute paths:

```
libfstats.so   NEEDED liblinalg.so / libcollections.so / libferror.so   RUNPATH $ORIGIN   SONAME libfstats.so
liblinalg.so   NEEDED libferror.so                                       RUNPATH $ORIGIN   SONAME liblinalg.so
```

`ldd` resolves all sibling deps via `$ORIGIN` with `LD_LIBRARY_PATH` unset. The consuming app (MT) builds and its full regression suite passes **963/0/0** against the rebuilt libraries — no numerical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)