### PR TITLE
fix: reject infeasible optimizer inputs and point-box-pinned fits

### DIFF
--- a/src/mt_borovicka.f90
+++ b/src/mt_borovicka.f90
@@ -51,7 +51,13 @@ real(real64), parameter :: EPS_PARALLEL = 1.0e-30_real64
 ! Generous bound on the free radiant ratios R[non-k]/R[k].
 real(real64), parameter :: RAD_BOUND = 5.0_real64
 
-! Proximity to +/-RAD_BOUND that counts as "on the bound".
+! Half-width (Mm) of the box on the two free point components, centred on the
+! seed point. BorovickaFitOnce builds those bounds from it and OnBound tests the
+! fitted point against the same two walls.
+real(real64), parameter :: POINT_BOUND = 1.0_real64
+
+! Proximity to a box wall -- +/-RAD_BOUND for a ratio, seed +/-POINT_BOUND for a
+! point component -- that counts as "on the bound".
 real(real64), parameter :: ONBOUND_TOL = 1.0e-9_real64
 
 ! Finite distance sentinel for a parallel sight. Squared by
@@ -274,23 +280,30 @@ subroutine BorovickaFF4Grad(&
 end subroutine BorovickaFF4Grad
 
 ! -----------------------------------------------------------------------
-! OnBound -- True if either free radiant ratio sits within ONBOUND_TOL of
-! +/-RAD_BOUND -- the pathological case that triggers a one-shot
+! OnBound -- True if the fit `q` ended pinned on any wall of the box
+! BorovickaFitOnce built around the seed `q0`: a free radiant ratio within
+! ONBOUND_TOL of +/-RAD_BOUND, or a free point component within
+! ONBOUND_TOL of q0 +/-POINT_BOUND. L-BFGS-B reports 'CONVERGENCE' with a
+! coordinate sitting on its wall -- the projected gradient of a
+! bound-active coordinate clamps to zero -- so a parameter pinned on the
+! seed-relative point box is not a trustworthy minimum any more than a
+! pinned ratio is. Both are the pathological case that triggers a one-shot
 ! re-pivot.
 ! -----------------------------------------------------------------------
-pure function OnBound(q) result(res)
-    real(real64), intent(in) :: q(NQ)
+pure function OnBound(q, q0) result(res)
+    real(real64), intent(in) :: q(NQ), q0(NQ)
     logical :: res
 
     res = (abs(abs(q(3)) - RAD_BOUND) < ONBOUND_TOL) .or. &
-          (abs(abs(q(4)) - RAD_BOUND) < ONBOUND_TOL)
+          (abs(abs(q(4)) - RAD_BOUND) < ONBOUND_TOL) .or. &
+          (abs(abs(q(1) - q0(1)) - POINT_BOUND) < ONBOUND_TOL) .or. &
+          (abs(abs(q(2) - q0(2)) - POINT_BOUND) < ONBOUND_TOL)
 end function OnBound
 
 ! -----------------------------------------------------------------------
-! BorovickaFitOnce -- One L-BFGS-B minimisation of FF4 under box bounds
-! Bounds:
-! the point-free parameters are q0(1:2) +/- 1
-! Mm, the radiant ratios +/-RAD_BOUND. The reverse-communication driver and
+! BorovickaFitOnce -- One L-BFGS-B minimisation of FF4 under box bounds.
+! Bounds: the point-free parameters are q0(1:2) +/-POINT_BOUND Mm, the
+! radiant ratios +/-RAD_BOUND. The reverse-communication driver and
 ! convergence-code mapping match MTExpFit:
 !   0 converged, 1 iteration limit, 51 warning, 52 abnormal/other.
 ! status is 0 when the optimiser ran, 1 when it could not be started at all.
@@ -349,11 +362,12 @@ subroutine BorovickaFitOnce(&
         return
     end if
 
-    ! Point-free parameters are bounded +/-1 Mm about the seed, ratios +/-5.
-    lower(1) = q0(1) - 1.0_real64
-    upper(1) = q0(1) + 1.0_real64
-    lower(2) = q0(2) - 1.0_real64
-    upper(2) = q0(2) + 1.0_real64
+    ! Point-free parameters are bounded +/-POINT_BOUND Mm about the seed, ratios
+    ! +/-RAD_BOUND.
+    lower(1) = q0(1) - POINT_BOUND
+    upper(1) = q0(1) + POINT_BOUND
+    lower(2) = q0(2) - POINT_BOUND
+    upper(2) = q0(2) + POINT_BOUND
     lower(3) = -RAD_BOUND
     upper(3) = RAD_BOUND
     lower(4) = -RAD_BOUND
@@ -491,7 +505,7 @@ subroutine BorovickaMinimize4(&
 
     call Reconstruct(qfit, k, pointFixed, P, R)
 
-    if (OnBound(qfit)) then
+    if (OnBound(qfit, q0)) then
         ! Bound-active fit: re-pivot ONCE onto the reconstructed radiant's argmax
         ! and refit, using purely local k2/pf2. Note pf2
         ! and q02 are built from the RECONSTRUCTED P and R, and R is normalised by
@@ -515,7 +529,8 @@ subroutine BorovickaMinimize4(&
         end if
         if (conv /= 0) return
         call Reconstruct(qfit, k2, pf2, P, R)
-        if (OnBound(qfit)) return   ! still bound-active -> non-converged
+        ! q0 now holds the re-pivot seed, so this tests the second fit's own box.
+        if (OnBound(qfit, q0)) return   ! still bound-active -> non-converged
     end if
 
     ! Degenerate-radiant gate, written as .not. (nrm >= EPS) rather than

--- a/src/mt_expfit.f90
+++ b/src/mt_expfit.f90
@@ -118,8 +118,9 @@ end subroutine ExpModelGrad
 !   51 -> warning termination (setulb task 'WARNING...')
 !   52 -> abnormal/other termination (incl. 'ABNORMAL...'/'ERROR...')
 ! `status` is 0 when the optimizer ran, or 1 when it could not be
-! started at all (invalid sizes / workspace allocation failure), in
-! which case `coef` = `seed`, `fval` = 0 and `convergence` = 52.
+! started at all (invalid sizes, an empty box, a negative `factr`, or a
+! workspace allocation failure), in which case `coef` = `seed`,
+! `fval` = 0 and `convergence` = 52.
 ! -----------------------------------------------------------------------
 subroutine ExpFitLBFGSB(&
     ndata, x, y, seed, lower, upper, maxit, lmm, factr, pgtol, coef, fval, convergence, status &
@@ -159,6 +160,15 @@ subroutine ExpFitLBFGSB(&
     g = 0.0_real64
 
     if (ndata < 1 .or. lmm < 1 .or. maxit < 0) then
+        status = 1
+        return
+    end if
+    ! An empty box (any lower bound above its upper bound) has no feasible point.
+    ! A negative factr is likewise not a stop tolerance setulb can honour. Either
+    ! makes setulb terminate on an error task before the first function
+    ! evaluation, leaving `fval` unwritten -- which the caller must not read as a
+    ! fit, so it is rejected here instead.
+    if (any(lower > upper) .or. factr < 0.0_real64) then
         status = 1
         return
     end if

--- a/src/mt_loess.f90
+++ b/src/mt_loess.f90
@@ -64,8 +64,10 @@ subroutine LoessFit(n, x, y, span, degree, ys, status)
     ys = 0.0_real64
     p = degree + 1
 
-    ! Neighbourhood size q = min(n, floor(span*n + Q_TOL)); q >= p is needed for
-    ! a determined local polynomial (the per-point npos check below enforces it).
+    ! Neighbourhood size q = min(n, floor(span*n + Q_TOL)). The tricube support is
+    ! strict (d(j) < dmax, dmax being the q-th smallest distance), so at most q-1
+    ! points carry positive weight and a determined local polynomial needs
+    ! q >= p+1 (the per-point npos check below enforces it).
     q = min(n, int(floor(span * real(n, real64) + Q_TOL), int32))
     if (q < 1) then
         status = 2


### PR DESCRIPTION
Companion to MT PR fduris/MT#515, whose submodule gitlink references this branch's head (`32b1d1a`). Merge alongside it so the gitlink lands on a commit reachable from `main` (same mechanics as #7).

Two behavior fixes plus one comment correction, found in the MT-side deep review:

- **ExpFitLBFGSB**: an infeasible box (`any(lower > upper)`) or a negative `factr` previously reached `setulb`, whose `errclb` error return maps to `convergence=52` with `status=0` and `f` never written — the caller received the seed back as a perfect fit (sigma 0) with no error. Both inputs now fail fast with `status=1`, matching the Gauss-Newton path's existing box check.
- **BorovickaMinimize4 / OnBound**: the bound-pinned rejection tested only the radiant ratios `q(3:4)`, while `BorovickaFitOnce` also boxes the point parameters `q(1:2)` to the seed ±1 Mm. A fit pinned on that point wall satisfied L-BFGS-B's CONVERGENCE (projected gradient of a bound-active coordinate clamps to zero) and was accepted as converged with a silently clamped point. `OnBound` now takes the seed and tests all four walls; the half-width is lifted into `POINT_BOUND` so the bounds and the test cannot drift apart.
- **mt_loess**: the neighbourhood-size comment claimed `q >= p` suffices; the strict `d(j) < dmax` support gives at most `q-1` positive-weight points, so the real requirement is `q >= p+1`. Comment only; the predicate is deliberate.

Verified from the MT side: full suite 1389 tests / 0 failures / 0 errors against the rebuilt artifacts, including a new regression test that fails against the pre-fix library; the Borovicka golden suite (40 tests) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)