### PR TITLE
Zero the PE build timestamp in win64 release links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,19 @@ set(MT_DIR "${CMAKE_BINARY_DIR}/../../..")
 # target_link_options on, and a per-target flag would strip fstats alone.
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -s")
 
+# The win64 artifacts additionally ship with a zeroed build timestamp. GNU ld
+# stamps the wall-clock build time into both the PE COFF header and the export
+# directory, so two links of byte-identical objects still differ there -- and in
+# the PE checksum that covers them -- which is enough to defeat an md5 check of
+# a committed DLL against a rebuild. `--no-insert-timestamp` zeroes both copies.
+# It is a PE-only option that the native ELF linker rejects outright, so it has
+# to stay behind the MINGW guard rather than join the `-s` above; it sits at the
+# same scope for the same reason, so that the dependency subdirectories inherit
+# it too.
+if (MINGW)
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--no-insert-timestamp")
+endif()
+
 add_subdirectory(configure)
 add_subdirectory(dependencies)
 


### PR DESCRIPTION
Adds -Wl,--no-insert-timestamp to the mingw release link flags (guarded — the native ELF linker rejects the option), zeroing the COFF-header and export-directory stamps so cross-builds stop differing by wall-clock. Verified on both configure paths: mingw carries the flag on all six link rules including the fetched BLAS/LAPACK; native is untouched. Recipe-only — the committed consumer artifacts are deliberately not rebuilt (they predate the current sources, and the BLAS/LAPACK numerics hazard recorded in the pinning PR applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)